### PR TITLE
Documentation on how to run the test suite locally

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -221,10 +221,23 @@ When a pre-built binary does not exist for your system you can build the project
 PostgREST Test Suite
 --------------------
 
-Creating the Test Database
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+To properly run the test suite, you need a Postgres database that the tests can run against. There are several ways to set up this database. 
 
-To properly run postgrest tests one needs to create a database. To do so, use the test creation script :code:`create_test_database` in the :code:`test/` folder.
+Testing with a temporary database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have Postgres installed locally (:code:`initdb`, :code:`pg_ctl` and :code:`psql` should be on your PATH, no server needs to be running), you can run the test suite against a temporary database:
+
+.. code:: bash
+
+   test/with_tmp_db stack test
+   
+The :code:`with_tmp_db` script will set up a new Postgres cluster in a temporary directory, set the required environment variables and run the command that you passed it as an argument, :code:`stack test` in the example above. When the command is done, the temporary database is torn down and deleted again.
+
+Manually creating the Test Database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To manually create a database for testing, use the test creation script :code:`create_test_database` in the :code:`test/` folder.
 
 The script expects the following parameters:
 
@@ -246,8 +259,8 @@ The script will return the db uri to use in the tests--this uri corresponds to t
 
 Generating the user and the password allows one to create the database and run the tests against any PostgreSQL server without any modifications to the server. (Such as allowing accounts without a password or setting up trust authentication, or requiring the server to be on the same localhost the tests are run from).
 
-Running the Tests
-~~~~~~~~~~~~~~~~~
+Running the Tests with the manually created database
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To run the tests, one must supply the database uri in the environment variable :code:`POSTGREST_TEST_CONNECTION`.
 
@@ -321,3 +334,14 @@ Stack test in Docker for Mac, PostgreSQL app on mac:
   $ export POSTGREST_TEST_CONNECTION=$(test/create_test_db "postgres://postgres@$HOST" test_db)
   $ docker run --rm -it -v `pwd`:`pwd` -v ~/.stack-linux:/root/.stack -v `pwd`/.stack-work-docker:`pwd`/.stack-work -e "HOST=$host_ip" -e "POSTGREST_TEST_CONNECTION=$POSTGREST_TEST_CONNECTION" -w="`pwd`" pgst-test bash -c "stack test"
   $ test/destroy_test_db "postgres://postgres@localhost" test_db
+
+Testing against several Postgres versions locally with Nix
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using `Nix <https://nixos.org/download.html>`_, you can run the tests against several versions of Postgres in one go:
+
+.. code:: bash
+
+   nix-shell -f test/default.nix --run postgrest-test-all
+   
+The :code:`postgrest-test-all` script sets up temporary local databases with earch version of Postgres and runs the tests against all those databases.


### PR DESCRIPTION
Documentation on the alternative ways to run tests locally that would be added with https://github.com/PostgREST/postgrest/pull/1476 and https://github.com/PostgREST/postgrest/pull/1480.